### PR TITLE
Correct StockPrices_Small.csv filename for case sensitive file-systems.

### DIFF
--- a/src/Linux/03/Completed/StockAnalyzer.Linux/MainWindow.xaml.cs
+++ b/src/Linux/03/Completed/StockAnalyzer.Linux/MainWindow.xaml.cs
@@ -407,7 +407,7 @@ namespace StockAnalyzer.Linux
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Linux/03/Start_Here/StockAnalyzer.Linux/MainWindow.xaml.cs
+++ b/src/Linux/03/Start_Here/StockAnalyzer.Linux/MainWindow.xaml.cs
@@ -71,7 +71,7 @@ namespace StockAnalyzer.Linux
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Linux/04/Completed/StockAnalyzer.Linux/MainWindow.xaml.cs
+++ b/src/Linux/04/Completed/StockAnalyzer.Linux/MainWindow.xaml.cs
@@ -451,7 +451,7 @@ namespace StockAnalyzer.Linux
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Linux/04/Completed/StockAnalyzer.Linux/Services/StockStreamService.cs
+++ b/src/Linux/04/Completed/StockAnalyzer.Linux/Services/StockStreamService.cs
@@ -37,7 +37,7 @@ namespace StockAnalyzer.Linux.Services
         public async IAsyncEnumerable<StockPrice> GetAllStockPrices(CancellationToken cancellationToken = default)
         {
             using var stream =
-                new StreamReader(File.OpenRead(@"StockPrices_small.csv"));
+                new StreamReader(File.OpenRead(@"StockPrices_Small.csv"));
 
             await stream.ReadLineAsync();
 

--- a/src/Linux/04/Start_Here/StockAnalyzer.Linux/MainWindow.xaml.cs
+++ b/src/Linux/04/Start_Here/StockAnalyzer.Linux/MainWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace StockAnalyzer.Linux
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Linux/05/Completed/StockAnalyzer.Linux/Services/StockStreamService.cs
+++ b/src/Linux/05/Completed/StockAnalyzer.Linux/Services/StockStreamService.cs
@@ -37,7 +37,7 @@ namespace StockAnalyzer.Linux.Services
         public async IAsyncEnumerable<StockPrice> GetAllStockPrices(CancellationToken cancellationToken = default)
         {
             using var stream =
-                new StreamReader(File.OpenRead(@"StockPrices_small.csv"));
+                new StreamReader(File.OpenRead(@"StockPrices_Small.csv"));
 
             await stream.ReadLineAsync();
 

--- a/src/Linux/05/Start_Here/StockAnalyzer.Linux/MainWindow.xaml.cs
+++ b/src/Linux/05/Start_Here/StockAnalyzer.Linux/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace StockAnalyzer.Linux
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/MacOS/03/Completed/StockAnalyzer.MacOS/MainWindow.xaml.cs
+++ b/src/MacOS/03/Completed/StockAnalyzer.MacOS/MainWindow.xaml.cs
@@ -407,7 +407,7 @@ namespace StockAnalyzer.MacOS
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/MacOS/03/Start_Here/StockAnalyzer.MacOS/MainWindow.xaml.cs
+++ b/src/MacOS/03/Start_Here/StockAnalyzer.MacOS/MainWindow.xaml.cs
@@ -71,7 +71,7 @@ namespace StockAnalyzer.MacOS
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/MacOS/04/Completed/StockAnalyzer.MacOS/MainWindow.xaml.cs
+++ b/src/MacOS/04/Completed/StockAnalyzer.MacOS/MainWindow.xaml.cs
@@ -451,7 +451,7 @@ namespace StockAnalyzer.MacOS
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/MacOS/04/Completed/StockAnalyzer.MacOS/Services/StockStreamService.cs
+++ b/src/MacOS/04/Completed/StockAnalyzer.MacOS/Services/StockStreamService.cs
@@ -37,7 +37,7 @@ namespace StockAnalyzer.MacOS.Services
         public async IAsyncEnumerable<StockPrice> GetAllStockPrices(CancellationToken cancellationToken = default)
         {
             using var stream =
-                new StreamReader(File.OpenRead(@"StockPrices_small.csv"));
+                new StreamReader(File.OpenRead(@"StockPrices_Small.csv"));
 
             await stream.ReadLineAsync();
 

--- a/src/MacOS/04/Start_Here/StockAnalyzer.MacOS/MainWindow.xaml.cs
+++ b/src/MacOS/04/Start_Here/StockAnalyzer.MacOS/MainWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace StockAnalyzer.MacOS
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/MacOS/05/Completed/StockAnalyzer.MacOS/Services/StockStreamService.cs
+++ b/src/MacOS/05/Completed/StockAnalyzer.MacOS/Services/StockStreamService.cs
@@ -37,7 +37,7 @@ namespace StockAnalyzer.MacOS.Services
         public async IAsyncEnumerable<StockPrice> GetAllStockPrices(CancellationToken cancellationToken = default)
         {
             using var stream =
-                new StreamReader(File.OpenRead(@"StockPrices_small.csv"));
+                new StreamReader(File.OpenRead(@"StockPrices_Small.csv"));
 
             await stream.ReadLineAsync();
 

--- a/src/MacOS/05/Start_Here/StockAnalyzer.MacOS/MainWindow.xaml.cs
+++ b/src/MacOS/05/Start_Here/StockAnalyzer.MacOS/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace StockAnalyzer.MacOS
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Windows/03/Completed/StockAnalyzer.Windows/MainWindow.xaml.cs
+++ b/src/Windows/03/Completed/StockAnalyzer.Windows/MainWindow.xaml.cs
@@ -402,7 +402,7 @@ namespace StockAnalyzer.Windows
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Windows/03/Start_Here/StockAnalyzer.Windows/MainWindow.xaml.cs
+++ b/src/Windows/03/Start_Here/StockAnalyzer.Windows/MainWindow.xaml.cs
@@ -74,7 +74,7 @@ namespace StockAnalyzer.Windows
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Windows/04/Completed/StockAnalyzer.Windows/MainWindow.xaml.cs
+++ b/src/Windows/04/Completed/StockAnalyzer.Windows/MainWindow.xaml.cs
@@ -371,7 +371,7 @@ namespace StockAnalyzer.Windows
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Windows/04/Start_Here/StockAnalyzer.Windows/MainWindow.xaml.cs
+++ b/src/Windows/04/Start_Here/StockAnalyzer.Windows/MainWindow.xaml.cs
@@ -95,7 +95,7 @@ namespace StockAnalyzer.Windows
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)

--- a/src/Windows/05/Completed/StockAnalyzer.Windows.Core/Services/StockStreamService.cs
+++ b/src/Windows/05/Completed/StockAnalyzer.Windows.Core/Services/StockStreamService.cs
@@ -37,7 +37,7 @@ namespace StockAnalyzer.Windows.Services
         public async IAsyncEnumerable<StockPrice> GetAllStockPrices(CancellationToken cancellationToken = default)
         {
             using var stream = 
-                new StreamReader(File.OpenRead(@"StockPrices_small.csv"));
+                new StreamReader(File.OpenRead(@"StockPrices_Small.csv"));
 
             await stream.ReadLineAsync();
 

--- a/src/Windows/05/Start_Here/StockAnalyzer.Windows/MainWindow.xaml.cs
+++ b/src/Windows/05/Start_Here/StockAnalyzer.Windows/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace StockAnalyzer.Windows
             {
                 var lines = new List<string>();
 
-                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_small.csv")))
+                using (var stream = new StreamReader(File.OpenRead(@"StockPrices_Small.csv")))
                 {
                     string line;
                     while ((line = await stream.ReadLineAsync()) != null)


### PR DESCRIPTION
Fix for reported error in GNU/Linux...
```
Could not find file 'getting-started-with-asynchronous-programming-dotnet/src/Linux/05/Completed/StockAnalyzer.Linux/bin/Debug/netcoreapp3.0/StockPrices_Small.csv'.
```

GNU/Linux is case sensitive.  
Code was trying to open file `StockPrices_Small.csv` as `StockPrices_small.csv`.  
This will likely only be an issue on *nix.  

Error was observed in Arch Linux... I cant imagine why you could not re-produce this in Ubuntu...  
Perhaps you were building from a case insensitive file-system?  

Thank you for creating this branch for me! It was a huge help!